### PR TITLE
Fix `heroku addons`

### DIFF
--- a/lib/ext/heroku/command/addons.rb
+++ b/lib/ext/heroku/command/addons.rb
@@ -45,8 +45,8 @@ module Heroku::Command
           addon_name = addon['name'].downcase
           [
             addon['plan']['name'],
-            attachments_by_resource[addon['id']].join(", "),
-            "@#{addon_name}"
+            "@#{addon_name}",
+            attachments_by_resource[addon['id']].join(", ")
           ]
         end)
       end


### PR DESCRIPTION
A modification to the format of AppAddon names from the edge `addons` endpoint caused a mismatch with the format of data coming from the edge `addon-attachments` endpoint; I've a pull-request in API to reconcile the two, but @bjeanes  suggested this very sensible solution and improvement all in one. :boom: 
