### PR TITLE
Add state to add-on service listing

### DIFF
--- a/lib/ext/heroku/command/addons.rb
+++ b/lib/ext/heroku/command/addons.rb
@@ -60,7 +60,7 @@ module Heroku::Command
         :path     => "/addon-services"
       ).body
 
-      display_table(addon_services, %w[name human_name], %w[Slug Name])
+      display_table(addon_services, %w[name human_name state], %w[Slug Name State])
       display "\nSee plans with `heroku addons:plans SERVICE`"
     end
 


### PR DESCRIPTION
Now that service state is in the API, we can present it in the listing.

Listing now looks like:

``` sh-session
$ heroku addons:services
Slug                Name                                   State
------------------  -------------------------------------  -----
adept-scale         Adept Scale                            ga
adminium            Adminium                               ga
airbrake            Airbrake Bug Tracker                   ga
algoliasearch       Algolia Realtime Search                ga
appsignal           AppSignal                              ga
asposecloud         Aspose for Cloud                       beta
auth0               Auth0                                  ga
autobus             Autobus                                beta
bablic              Bablic                                 beta
blackfire           Blackfire Profiler                     beta
...
```

cc @heroku/add-ons 