### PR TITLE
Replace pg:promote command with one that uses the attachments API

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -2,4 +2,5 @@
 require("heroku/command/addons")
 
 # load overrides
+require("#{File.dirname(__FILE__)}/lib/ext/heroku/command/pg")
 require("#{File.dirname(__FILE__)}/lib/ext/heroku/command/addons")

--- a/lib/ext/heroku/command/pg.rb
+++ b/lib/ext/heroku/command/pg.rb
@@ -1,0 +1,42 @@
+require "heroku/helpers/heroku_postgresql"
+require "ext/heroku/helpers/addons/resolve"
+require "ext/heroku/helpers/addons/api"
+
+module Heroku::Command
+
+  # manage heroku-postgresql databases
+  #
+  class Pg < Base
+    include Heroku::Helpers::Addons::Resolve
+    include Heroku::Helpers::Addons::API
+
+    # pg:promote DATABASE
+    #
+    # sets DATABASE as your DATABASE_URL
+    #
+    def promote
+      requires_preauth
+      unless db = shift_argument
+        error("Usage: heroku pg:promote DATABASE\nMust specify DATABASE to promote.")
+      end
+      validate_arguments!
+
+      addon = resolve_addon!(db)
+
+      attachment_name = 'DATABASE'
+      action "Promoting #{addon['name']} to #{attachment_name}_URL on #{app}" do
+        request(
+          :body     => json_encode({
+            "app"     => {"name" => app},
+            "addon"   => {"name" => addon['name']},
+            "confirm" => app,
+            "name"    => attachment_name
+          }),
+          :expects  => 201,
+          :method   => :post,
+          :path     => "/addon-attachments"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Includes part of #41, ~~which hasn't been merged yet~~.

No more glorified `config:set`. Paves the way for deprecating implicit attachments.

attn @heroku/add-ons 